### PR TITLE
Fix report run date

### DIFF
--- a/analysis/report.ipynb
+++ b/analysis/report.ipynb
@@ -6,8 +6,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from datetime import date\n",
+    "import dateutil\n",
     "from IPython.display import Markdown\n",
+    "import json\n",
     "import pandas\n",
     "import pathlib"
    ]
@@ -38,6 +39,31 @@
    "outputs": [],
    "source": [
     "rows = pandas.read_csv(OUTPUT_DIR / \"rows.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "log = {\n",
+    "    d[\"event\"]: d\n",
+    "    for d in (json.loads(l) for l in (OUTPUT_DIR / \"log.json\").read_text().splitlines())\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Although a misnomer, the report run date is the date the query was executed\n",
+    "# rather than the date the report was rendered.\n",
+    "report_run_date = dateutil.parser.parse(\n",
+    "    log.get(\"finish_executing_sql_query\", {}).get(\"timestamp\", \"9999-01-01T00:00:00\")\n",
+    ")"
    ]
   },
   {
@@ -100,7 +126,7 @@
    "source": [
     "Markdown(\n",
     "    f\"\"\"\n",
-    "This report was run on {date.today():%Y-%m-%d}.\n",
+    "This report was run on {report_run_date:%Y-%m-%d}.\n",
     "It reflects the state of the database on this date.\n",
     "\"\"\"\n",
     ")"

--- a/project.yaml
+++ b/project.yaml
@@ -9,10 +9,12 @@ actions:
       sqlrunner:latest
         --output output/rows.csv
         --dummy-data-file analysis/dummy_rows.csv
+        --log-file output/log.json
         analysis/query.sql
     outputs:
       moderately_sensitive:
         rows: output/rows.csv
+        log: output/log.json
 
   make-html-reports:
     # --execute


### PR DESCRIPTION
The report run date is now the date the query was executed, rather than the date the report was rendered.

Follows opensafely-core/sqlrunner#104.

Fixes #9