### PR TITLE
Require appnope

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -4,6 +4,7 @@
 # To generate a requirements file that includes both prod and dev requirements, run:
 # pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 
+appnope
 black[jupyter]
 flake8
 flake8-builtins

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,6 +8,12 @@ appdirs==1.4.4 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
     # via sqlfluff
+appnope==0.1.3 \
+    --hash=sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24 \
+    --hash=sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e
+    # via
+    #   -r requirements.dev.in
+    #   ipython
 asttokens==2.0.8 \
     --hash=sha256:c61e16246ecfb2cde2958406b4c8ebc043c9e6d73aaa83c941673b35e5d3a76b \
     --hash=sha256:e3305297c744ae53ffa032c45dc347286165e4ffce6875dc662b205db0623d86


### PR DESCRIPTION
Doing so makes life easier for anyone who develops on macOS, as it's missed by Dependabot.