### PR TITLE
Remove dummy rows

### DIFF
--- a/analysis/dummy_rows.csv
+++ b/analysis/dummy_rows.csv
@@ -1,1 +1,0 @@
-DataSource,TableName,ColumnName,ColumnType,Precision,Scale,MaxLength,IsNullable,CollationName

--- a/project.yaml
+++ b/project.yaml
@@ -8,7 +8,6 @@ actions:
     run: >
       sqlrunner:latest
         --output output/rows.csv
-        --dummy-data-file analysis/dummy_rows.csv
         --log-file output/log.json
         analysis/query.sql
     outputs:


### PR DESCRIPTION
Following opensafely-core/sqlrunner#159, SQL Runner will generate column headers from the query, so we need not supply them.