### PR TITLE
Include the contents of the `DataDictionary` table

### DIFF
--- a/analysis/data_dictionary_query.sql
+++ b/analysis/data_dictionary_query.sql
@@ -1,0 +1,9 @@
+-- We don't query either patient-level or event-level data, so we need not
+-- exclude T1OOs using the PatientsWithTypeOneDissent table.
+SELECT
+    [Table],
+    Type,
+    Code,
+    Description
+FROM DataDictionary
+ORDER BY [Table], Type;

--- a/project.yaml
+++ b/project.yaml
@@ -15,6 +15,17 @@ actions:
         rows: output/rows.csv
         log: output/log.json
 
+  data_dictionary_query:
+    run: >
+      sqlrunner:latest
+        --output output/data_dictionary.csv
+        --log-file output/data_dictionary_log.json
+        analysis/data_dictionary_query.sql
+    outputs:
+      moderately_sensitive:
+        rows: output/data_dictionary.csv
+        log: output/data_dictionary_log.json
+
   make-html-reports:
     # --execute
     #   execute notebooks before converting them to HTML reports


### PR DESCRIPTION
I don't thinks there's any need at this stage to include it in the HTML report. The primary purpose is to support ingesting it into ehrQL as described in the ticket below.

Closes #134