### PR TITLE
Include `DecisionSupportValueReference` table

### DIFF
--- a/analysis/decision_support_value_reference_query.sql
+++ b/analysis/decision_support_value_reference_query.sql
@@ -1,0 +1,9 @@
+-- We don't query either patient-level or event-level data, so we need not
+-- exclude T1OOs using the AllowedPatientsWithTypeOneDissent table.
+SELECT
+    AlgorithmType,
+    AlgorithmDescription,
+    AlgorithmVersion,
+    AlgorithmSourceLink
+FROM DecisionSupportValueReference
+ORDER BY AlgorithmType;

--- a/project.yaml
+++ b/project.yaml
@@ -26,6 +26,17 @@ actions:
         rows: output/data_dictionary.csv
         log: output/data_dictionary_log.json
 
+  decision_support_value_reference_query:
+    run: >
+      sqlrunner:latest
+        --output output/decision_support_value_reference.csv
+        --log-file output/decision_support_value_reference_log.json
+        analysis/decision_support_value_reference_query.sql
+    outputs:
+      moderately_sensitive:
+        rows: output/decision_support_value_reference.csv
+        log: output/decision_support_value_reference_log.json
+
   make-html-reports:
     # --execute
     #   execute notebooks before converting them to HTML reports


### PR DESCRIPTION
This is another "data dictionary" table, not one which contains any patient data.

It currently contains only a single row which looks like:

AlgorithmType | AlgorithmDescription              | AlgorithmVersion | AlgorithmSourceLink
------------- | --------------------------------- | ---------------- | --------------------
1             | UK Electronic Frailty Index (eFI) | 1.0              | https://academic.oup.com/ageing/article/45/3/353/1739750

But it would be good to automate the process of keeping this up-to-date if TPP end up adding more.