### PR TITLE
Order schema by `ColumnName` as well as `TableName`

### DIFF
--- a/analysis/query.sql
+++ b/analysis/query.sql
@@ -13,4 +13,4 @@ SELECT
 FROM OpenSAFELYSchemaInformation
 WHERE
     DataSource != 'ONS_CIS'
-ORDER BY DataSource, TableName;
+ORDER BY DataSource, TableName, ColumnName;


### PR DESCRIPTION
This is to avoid unnecessary diff noise as otherwise the column order is not consistent between runs. See e.g.
 * https://github.com/opensafely-core/ehrql/pull/2412